### PR TITLE
Fixing npm audit problem by upgrading js-yaml to version >= 3.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/cutsin/require-yml",
   "dependencies": {
-    "js-yaml": "~3.2.5"
+    "js-yaml": "~3.13.0"
   }
 }


### PR DESCRIPTION
Hi,

currently, the npm audit suggests an upgrade of the js-yaml package to a version 3.13.0. Please consider this pull request.

Thanks,
   Tobias.